### PR TITLE
Potential fix for code scanning alert no. 1: Shell command built from environment values

### DIFF
--- a/packages/testing-kit/bin/testing-kit.js
+++ b/packages/testing-kit/bin/testing-kit.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-const { execSync } = require('child_process')
+const { execFileSync } = require('child_process')
 const path = require('path')
 const fs = require('fs')
 
@@ -40,9 +40,9 @@ try {
   process.env.TS_NODE_PROJECT = `${projectRoot}/tsconfig.json`
 
   if (command === 'test' && directory) {
-    execSync(`yarn ${command} ${path.join(projectRoot, directory)}`, { stdio: 'inherit' })
+    execFileSync('yarn', [command, path.join(projectRoot, directory)], { stdio: 'inherit' })
   } else {
-    execSync(`yarn ${command}`, { stdio: 'inherit' })
+    execFileSync('yarn', [command], { stdio: 'inherit' })
   }
 } catch (error) {
   console.error(`Failed to execute Hardhat command: ${error.message}`)


### PR DESCRIPTION
Potential fix for [https://github.com/Safe-app-eth/safe-core-sdk/security/code-scanning/1](https://github.com/Safe-app-eth/safe-core-sdk/security/code-scanning/1)

To fix the issue, we should avoid dynamically constructing the shell command as a single string. Instead, we should use `execFileSync` from the `child_process` module, which allows us to pass the command and its arguments as separate parameters. This approach avoids shell interpretation of the arguments, mitigating the risk of command injection.

Specifically:
1. Replace the use of `execSync` with `execFileSync`.
2. Pass `yarn` as the command and the remaining parts (`command` and the resolved `directory` path) as an array of arguments.
3. Ensure that `directory` is validated or sanitized before use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
